### PR TITLE
Fix raising of 'UploadFailed' event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 1.0.2
+
+* Fixed: Raising of UploadFailed event.
+
 ### 1.0.1
 
 * Changed: Can now be used to select multiple files to upload at once

--- a/src/Html5FileUploadViewBridge.js
+++ b/src/Html5FileUploadViewBridge.js
@@ -282,10 +282,9 @@ window.rhubarb.vb.create("Html5FileUploadViewBridge", function(parent){
                 }.bind(this),
                 // On failure
                 function (response) {
-
                     this.uploadNextFile();
                     this.raiseClientEvent("UploadFailed", file, response);
-                }
+                }.bind(this)
             );
 
             return this.request;


### PR DESCRIPTION
Bind 'this', the ViewBridge, to anonymous function within which "UploadFailed" event is raised using
this.raiseClientEvent( ... )